### PR TITLE
refactor(shell): share runtime between bash and zsh

### DIFF
--- a/bin/copy_files.rb
+++ b/bin/copy_files.rb
@@ -25,6 +25,7 @@ def sync_shell_files(config_dir, home)
   link_file "#{config_dir}/shell/aliases", "#{home}/.shell/.aliases"
   link_file "#{config_dir}/shell/env", "#{home}/.shell/.env"
   link_file "#{config_dir}/shell/funcs", "#{home}/.shell/.funcs"
+  link_file "#{config_dir}/shell/shellrc", "#{home}/.shell/.shellrc"
   link_file "#{config_dir}/shell/tmux.conf", "#{home}/.tmux.conf"
   
   link_file "#{config_dir}/shell/bashrc", "#{home}/.bashrc"

--- a/shell/aliases
+++ b/shell/aliases
@@ -14,9 +14,10 @@ alias git-amn='git ci -v --amend --signoff'
 alias gs='git status -s'
 # Show the commits for today
 alias heute='git shortlog --since=1day'
-# Pull in new changes from configuration files if any.
-if [[ "$DOTFILES_OS" == "gitbash" ]]; then
-  alias reload='source ~/.bashrc'
+# Pull in new changes from configuration files if any. Reload the rc for the
+# current shell so `reload` works under both bash and zsh.
+if [ -n "$ZSH_VERSION" ]; then
+  alias reload='source ~/.zshrc'
 else
   alias reload='source ~/.bashrc'
 fi

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -1,28 +1,7 @@
 # vi:syntax=sh
 
-# Detect Git Bash on Windows
-if [[ "$(uname -s)" =~ MINGW* || "$(uname -s)" =~ MSYS* ]]; then
-  export DOTFILES_OS="gitbash"
-else
-  export DOTFILES_OS="unix"
-fi
-
+# bash-only completion
 source $HOME/.git-completion.bash
-source $HOME/.shell/.aliases
-source $HOME/.shell/.env
-source $HOME/.shell/.funcs
 
-# Only run ulimit on non-Windows
-if [[ "$DOTFILES_OS" != "gitbash" ]]; then
-  ulimit -c 256
-fi
-
-if [ -f /etc/fedora-release ]; then
-  . /usr/share/powerline/bash/powerline.sh
-elif [ -f /etc/debian-release ]; then
-  . /usr/share/powerline/bindings/bash/powerline.sh
-fi
-
-if [[ "$TERMINOLOGY" -eq "1" ]]; then
-    pokemon
-fi
+# Shared runtime (env, aliases, funcs, ulimit, powerline, ...)
+source $HOME/.shell/.shellrc

--- a/shell/env
+++ b/shell/env
@@ -8,6 +8,7 @@ else
 fi
 
 export VISUAL=vim
+export EDITOR=vim
 
 # Locale
 if [[ "$DOTFILES_OS" != "gitbash" ]]; then

--- a/shell/shellrc
+++ b/shell/shellrc
@@ -1,0 +1,46 @@
+# vi:syntax=sh
+#
+# Shared shell runtime, sourced by both .bashrc and .zshrc.
+# Keep shell-agnostic logic here; put bash-only / zsh-only bits in their rc.
+
+# Detect the running shell so shell-specific paths can be selected below.
+if [ -n "$ZSH_VERSION" ]; then
+  DOTFILES_SHELL=zsh
+elif [ -n "$BASH_VERSION" ]; then
+  DOTFILES_SHELL=bash
+else
+  DOTFILES_SHELL=sh
+fi
+export DOTFILES_SHELL
+
+# Shared config. .env defines DOTFILES_OS, so source it first.
+[ -f "$HOME/.shell/.env" ]     && . "$HOME/.shell/.env"
+[ -f "$HOME/.shell/.aliases" ] && . "$HOME/.shell/.aliases"
+[ -f "$HOME/.shell/.funcs" ]   && . "$HOME/.shell/.funcs"
+
+# Core dump limit (skip on Git Bash, no ulimit there).
+if [ "$DOTFILES_OS" != "gitbash" ]; then
+  ulimit -c 256
+fi
+
+# Powerline. Binding directory and file extension differ per shell.
+if [ "$DOTFILES_SHELL" = "zsh" ]; then
+  _pl_ext=zsh
+else
+  _pl_ext=sh
+fi
+if [ -f /etc/fedora-release ]; then
+  [ -f "/usr/share/powerline/$DOTFILES_SHELL/powerline.$_pl_ext" ] && \
+    . "/usr/share/powerline/$DOTFILES_SHELL/powerline.$_pl_ext"
+elif [ -f /etc/debian-release ]; then
+  [ -f "/usr/share/powerline/bindings/$DOTFILES_SHELL/powerline.$_pl_ext" ] && \
+    . "/usr/share/powerline/bindings/$DOTFILES_SHELL/powerline.$_pl_ext"
+fi
+unset _pl_ext
+
+# Fun prompt under Terminology.
+if [ "$TERMINOLOGY" = "1" ]; then
+  pokemon
+fi
+
+unset LESS

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -3,11 +3,6 @@ ZSH_THEME="robbyrussell"
 
 plugins=(git)
 
-# Remove duplicate sourcing of aliases, funcs, env (already handled below)
-# source $HOME/.shell/.aliases
-# source $HOME/.shell/.funcs
-# source $HOME/.shell/.env
-
 # Profile zsh startup
 zmodload zsh/zprof
 
@@ -24,8 +19,8 @@ compinit -C
 
 setopt autocd
 
-# Set vim to default editor
-export EDITOR='vim'
+# Shared runtime (env, aliases, funcs, ulimit, powerline, ...)
+source $HOME/.shell/.shellrc
 
 if typeset -f nvm > /dev/null; then
   # Automatically switch node versions when a directory has a `.nvmrc` file
@@ -59,36 +54,6 @@ add-zsh-hook chpwd load-nvmrc
 load-nvmrc
 fi
 
-# --- Custom logic for dotfiles portability ---
-# Detect Git Bash on Windows
-if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
-  export DOTFILES_OS="gitbash"
-else
-  export DOTFILES_OS="unix"
-fi
-
-# Source dotfiles shell files if present
-[ -f $HOME/.shell/.aliases ] && source $HOME/.shell/.aliases
-[ -f $HOME/.shell/.env ] && source $HOME/.shell/.env
-[ -f $HOME/.shell/.funcs ] && source $HOME/.shell/.funcs
-
-# Only run ulimit on non-Windows
-if [[ "$DOTFILES_OS" != "gitbash" ]]; then
-  ulimit -c 256
-fi
-
-# Powerline for zsh (adjust path if needed)
-if [ -f /etc/fedora-release ]; then
-  [ -f /usr/share/powerline/zsh/powerline.zsh ] && source /usr/share/powerline/zsh/powerline.zsh
-elif [ -f /etc/debian-release ]; then
-  [ -f /usr/share/powerline/bindings/zsh/powerline.zsh ] && source /usr/share/powerline/bindings/zsh/powerline.zsh
-fi
-
-# Fun prompt if TERMINOLOGY is set
-if [[ "$TERMINOLOGY" -eq "1" ]]; then
-    pokemon
-fi
-
 # Use Spaceship prompt
 autoload -U promptinit; promptinit
 # prompt spaceship
@@ -97,5 +62,3 @@ setopt hist_ignore_all_dups # remove older duplicate entries from history
 setopt hist_reduce_blanks # remove superfluous blanks from history items
 setopt inc_append_history # save history entries as soon as they are entered
 setopt share_history # share history between different instances of the shell
-
-unset LESS;


### PR DESCRIPTION
## What

Dedupe the shell startup logic that was copy-pasted between `bashrc` and `zshrc`. New `shell/shellrc` holds the shell-agnostic runtime; both rc files source it and keep only their shell-specific bits.

## Changes

| File | Change |
|------|--------|
| `shell/shellrc` | **new** — shell detect, sources env/aliases/funcs, ulimit, powerline, Terminology, `unset LESS` |
| `shell/bashrc` | thin: git-completion + `source .shellrc` |
| `shell/zshrc` | oh-my-zsh + zsh-only (nvm chpwd hook, history setopts) + `source .shellrc`; dropped duplicated OS/source/ulimit/powerline block |
| `shell/env` | added `EDITOR=vim` (was zsh-only) |
| `shell/aliases` | `reload` now reloads current shell's rc (zsh→`~/.zshrc`) instead of always `~/.bashrc` |
| `bin/copy_files.rb` | symlink `shellrc` → `~/.shell/.shellrc` |

Powerline binding dir + extension are picked from the detected shell, so one block covers bash (`.sh`) and zsh (`.zsh`).

## Notes

- zsh already worked; this lowers duplication, no new behavior except the `reload` fix.
- `bash -n` / `zsh -n` pass on all rc files.
- Apply with `make copy` (relinks; backs up existing `~/.zshrc` to `.bak`), then `reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)